### PR TITLE
Fix/package data dir

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(name='tap-ebay',
       author='Fishtown Analytics',
       url='http://fishtownanalytics.com',
       classifiers=['Programming Language :: Python :: 3 :: Only'],
-      py_modules=['tab_ebay'],
+      py_modules=['tap_ebay'],
       install_requires=[
           'tap-framework==0.1.1',
       ],

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-ebay',
-      version='0.0.1',
+      version='0.0.2',
       description='Singer.io tap for extracting data from the Ebay API',
       author='Fishtown Analytics',
       url='http://fishtownanalytics.com',

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(name='tap-ebay',
       ''',
       packages=find_packages(),
       package_data={
-          'tap_lever': [
+          'tap_ebay': [
               'schemas/*.json'
           ]
       })


### PR DESCRIPTION
Fixes a bug which prevents `pip install tap-ebay` from working as expected. The json schemas included in this package were not installed because the `package_data` config pointed to the wrong package name.